### PR TITLE
Add autoload-cookie

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -155,6 +155,7 @@
   `(diff-indicator-removed ((t (:inherit diff-removed))))
 ))
 
+;;;###autoload
 (when load-file-name
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))


### PR DESCRIPTION
This commit ensures that users who have installed `gruvbox-theme` from a [MELPA](melpa.milkbox.net) package will be able to automatically be available without explicitly requiring the library first.
