### PR TITLE
Adds popup-tip-face colors to look nice with flycheck-pos-tip.

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -192,6 +192,9 @@
     `(js2-jsdoc-html-tag-name           ((t (:background nil :foreground ,gruvbox-light4 ))))
     `(js2-jsdoc-html-tag-delimiter      ((t (:background nil :foreground ,gruvbox-light3 ))))
 
+    ;; popup-tip
+    `(popup-tip-face                    ((t (:background ,gruvbox-dark1 :foreground ,gruvbox-neutral_yellow))))
+
     ;; helm
     `(helm-M-x-key                              ((t ( :foreground ,gruvbox-neutral_orange  ))))
     `(helm-action                               ((t ( :foreground ,gruvbox-white :underline t ))))


### PR DESCRIPTION
Contrieved example follows to show the effect

![Gruvbox playing nice with flycheck-pos-tip](https://s3.amazonaws.com/f.cl.ly/items/1C3O1Q1t450E3m0H3R30/Image%202015-06-22%20at%209.57.55%20pm.png)