### PR TITLE
Fixed line number being highlighed with parens

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -102,7 +102,7 @@
     `(mode-line                         ((t (:box nil :background ,gruvbox-dark2 :foreground ,gruvbox-light2))))
     `(mode-line-inactive                ((t (:box nil :background ,gruvbox-dark1 :foreground ,gruvbox-light4))))
     `(fringe                            ((t (:background ,gruvbox-dark0))))
-    `(linum                             ((t (:foreground ,gruvbox-dark4))))
+    `(linum                             ((t (:background ,gruvbox-dark0 :foreground ,gruvbox-dark4))))
     `(hl-line                           ((t (:background ,gruvbox-dark1))))
     `(region                            ((t (:background ,gruvbox-dark2)))) ;;selection
     `(secondary-selection               ((t (:background ,gruvbox-dark1))))


### PR DESCRIPTION
Hi, I fixed the line number being highlighed when the cursor is over a paren on the first column like this

![screenshot](https://cloud.githubusercontent.com/assets/6924220/11729676/4fe70c1c-9f88-11e5-8518-bba2fc893366.png)
