### PR TITLE
Change font-lock-function-name-face to yellow

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -112,7 +112,7 @@
     `(font-lock-builtin-face            ((t (:foreground ,gruvbox-neutral_orange))))
     `(font-lock-constant-face           ((t (:foreground ,gruvbox-neutral_purple))))
     `(font-lock-comment-face            ((t (:foreground ,gruvbox-dark4))))
-    `(font-lock-function-name-face      ((t (:foreground ,gruvbox-neutral_green))))
+    `(font-lock-function-name-face      ((t (:foreground ,gruvbox-neutral_yellow))))
     `(font-lock-keyword-face            ((t (:foreground ,gruvbox-neutral_red))))
     `(font-lock-string-face             ((t (:foreground ,gruvbox-neutral_green))))
     `(font-lock-variable-name-face      ((t (:foreground ,gruvbox-neutral_blue))))


### PR DESCRIPTION
Currently font-lock-string-face is set to green, which is already being used by font-lock-function-name-face. I think we should use yellow instead, which is currently not being used in font-lock definitions.

What do you think?

Cheers!
