### PR TITLE
Add support for message-mode

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -267,6 +267,18 @@
     `(term-default-fg-color             ((t (:foreground ,gruvbox-light0))))
     `(term-default-bg-color             ((t (:background ,gruvbox-dark0))))
 
+    ;; message-mode
+    `(message-header-to                 ((t (:inherit font-lock-variable-name-face))))
+    `(message-header-cc                 ((t (:inherit font-lock-variable-name-face))))
+    `(message-header-subject            ((t (:foreground ,gruvbox-neutral_orange :weight bold))))
+    `(message-header-newsgroups         ((t (:foreground ,gruvbox-neutral_yellow :weight bold))))
+    `(message-header-other              ((t (:inherit font-lock-variable-name-face))))
+    `(message-header-name               ((t (:inherit font-lock-keyword-face))))
+    `(message-header-xheader            ((t (:foreground ,gruvbox-faded_blue))))
+    `(message-separator                 ((t (:inherit font-lock-comment-face))))
+    `(message-cited-text                ((t (:inherit font-lock-comment-face))))
+    `(message-mml                       ((t (:foreground ,gruvbox-faded_green :weight bold))))
+
     ;; Smart-mode-line
     `(sml/global            ((t (:foreground ,gruvbox-burlywood4 :inverse-video nil))))
     `(sml/modes             ((t (:foreground ,gruvbox-bright_green))))


### PR DESCRIPTION
This commit adds a somewhat opinionated theme for `message-mode` buffers, intending to match other buffers instead of the default theme.

Before (default colours):

![screen shot 2016-09-06 at 8 36 45 pm](https://cloud.githubusercontent.com/assets/1448326/18295735/ffa8e120-7471-11e6-815c-c95828e28561.png)

After:

![screen shot 2016-09-06 at 8 37 49 pm](https://cloud.githubusercontent.com/assets/1448326/18295744/0b452034-7472-11e6-87c3-63557fed0ec5.png)
