### PR TITLE
Add support for elfeed-mode

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -341,6 +341,16 @@
     `(org-habit-overdue-face            ((t (:background ,gruvbox-faded_red))))
     `(org-habit-overdue-future-face     ((t (:background ,gruvbox-neutral_red))))
 
+    ;; elfeed
+    `(elfeed-search-title-face          ((t (:foreground ,gruvbox-medium))))
+    `(elfeed-search-unread-title-face   ((t (:foreground ,gruvbox-light0))))
+    `(elfeed-search-date-face           ((t (:inherit font-lock-builtin-face :underline t))))
+    `(elfeed-search-feed-face           ((t (:inherit font-lock-variable-name-face))))
+    `(elfeed-search-tag-face            ((t (:inherit font-lock-keyword-face))))
+    `(elfeed-search-last-update-face    ((t (:inherit font-lock-comment-face))))
+    `(elfeed-search-unread-count-face   ((t (:inherit font-lock-comment-face))))
+    `(elfeed-search-filter-face         ((t (:inherit font-lock-string-face))))
+
     ;; Smart-mode-line
     `(sml/global            ((t (:foreground ,gruvbox-burlywood4 :inverse-video nil))))
     `(sml/modes             ((t (:foreground ,gruvbox-bright_green))))


### PR DESCRIPTION
Before (default colours):

![screen shot 2016-09-07 at 11 25 43 pm](https://cloud.githubusercontent.com/assets/1448326/18336141/cdb7d64e-7552-11e6-9c27-8a759b1b3b1d.png)

After:

![screen shot 2016-09-07 at 11 26 20 pm](https://cloud.githubusercontent.com/assets/1448326/18336144/d3d0854e-7552-11e6-9539-03a922b4b75c.png)

Generally followed the semantics of `font-lock-mode` on this one.