### PR TITLE
Use `cl-case` explicitly to avoid errors when compiling

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -33,6 +33,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl-macs))
+
 (unless (>= emacs-major-version 24)
   (error "Requires Emacs 24 or later"))
 
@@ -97,7 +100,7 @@
       (gruvbox-aquamarine4      (if (display-graphic-p) "#83A598" "aquamarine4"))
       (gruvbox-turquoise4       (if (display-graphic-p) "#61ACBB" "turquoise4"))
 
-      (gruvbox-bg (case gruvbox-contrast
+      (gruvbox-bg (cl-case gruvbox-contrast
 		    (hard gruvbox-dark0_hard)
 		    (soft gruvbox-dark0_soft)
 		    ;; Medium by default.


### PR DESCRIPTION
See the problem mentioned in #40.