### PR TITLE
Adding show-paren-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This theme contains custom support for the following features and plugins:
 - [ElScreen](https://github.com/knu/elscreen)
 - [ag.el](https://github.com/Wilfred/ag.el)
 - [js2-mode](https://github.com/mooz/js2-mode)
+- [Anzu](https://github.com/syohex/emacs-anzu#customization) support
 - Diffs
 - Term
 - Helm
@@ -67,7 +68,6 @@ None.  For now...
 
 ## To-do
 
-- [Anzu](https://github.com/syohex/emacs-anzu#customization) support
 - [ace-jump-mode](https://github.com/winterTTr/ace-jump-mode/blob/8351e2df4fbbeb2a4003f2fb39f46d33803f3dac/ace-jump-mode.el#L287) support
 - Light version of theme.
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -372,7 +372,11 @@
     `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
     `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
-    `(anzu-replace-highlight ((t (:inherit isearch)))))
+    `(anzu-replace-highlight ((t (:inherit isearch))))
+
+    ;; Show-paren-mode
+    `(show-paren-match      ((t (:background ,gruvbox-dark3 :weight bold))))
+    `(show-paren-mismatch   ((t (:background ,gruvbox-bright_red :foreground ,gruvbox-dark3 :weight bold)))))
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -362,7 +362,11 @@
     `(persp-selected-face   ((t (:foreground ,gruvbox-neutral_orange))))
 
     ;; anzu-mode
-    `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold)))))
+    `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold))))
+    `(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
+    `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
+    `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
+    `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow)))))
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -372,15 +372,11 @@
     `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
     `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
-<<<<<<< HEAD
     `(anzu-replace-highlight ((t (:inherit isearch))))
 
     ;; Show-paren-mode
     `(show-paren-match      ((t (:background ,gruvbox-dark3 :weight bold))))
     `(show-paren-mismatch   ((t (:background ,gruvbox-bright_red :foreground ,gruvbox-dark3 :weight bold)))))
-=======
-    `(anzu-replace-highlight ((t (:inherit isearch)))))
->>>>>>> c5d1867aa241f7ba61df9dce083be62c27d9a758
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -361,12 +361,17 @@
     `(sml/read-only         ((t (:foreground ,gruvbox-neutral_blue))))
     `(persp-selected-face   ((t (:foreground ,gruvbox-neutral_orange))))
 
+    ;;isearch
+    `(isearch                       ((t (:foreground ,gruvbox-dark0 :background ,gruvbox-neutral_orange))))
+    `(isearch-lazy-highlight-face   ((t (:foreground ,gruvbox-dark0 :background ,gruvbox-neutral_yellow))))
+
     ;; anzu-mode
     `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold))))
     `(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
     `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
     `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
-    `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow)))))
+    `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
+    `(anzu-replace-highlight ((t (:inherit isearch)))))
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -359,7 +359,10 @@
     `(sml/filename          ((t (:foreground ,gruvbox-bright_red :weight bold))))
     `(sml/prefix            ((t (:foreground ,gruvbox-light1))))
     `(sml/read-only         ((t (:foreground ,gruvbox-neutral_blue))))
-    `(persp-selected-face   ((t (:foreground ,gruvbox-neutral_orange)))))
+    `(persp-selected-face   ((t (:foreground ,gruvbox-neutral_orange))))
+
+    ;; anzu-mode
+    `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold)))))
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -363,7 +363,7 @@
 
         ;;isearch
     `(isearch                       ((t (:foreground ,gruvbox-black :background ,gruvbox-neutral_orange))))
-    `(lazy-highlight-face           ((t (:foreground ,gruvbox-black :background ,gruvbox-neutral_yellow))))
+    `(lazy-highlight           ((t (:foreground ,gruvbox-black :background ,gruvbox-neutral_yellow))))
     `(isearch-fail                  ((t (:foreground ,gruvbox-light0 :background ,gruvbox-bright_red))))
 
     ;; anzu-mode

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -361,15 +361,16 @@
     `(sml/read-only         ((t (:foreground ,gruvbox-neutral_blue))))
     `(persp-selected-face   ((t (:foreground ,gruvbox-neutral_orange))))
 
-    ;;isearch
-    `(isearch                       ((t (:foreground ,gruvbox-dark0 :background ,gruvbox-neutral_orange))))
-    `(isearch-lazy-highlight-face   ((t (:foreground ,gruvbox-dark0 :background ,gruvbox-neutral_yellow))))
+        ;;isearch
+    `(isearch                       ((t (:foreground ,gruvbox-black :background ,gruvbox-neutral_orange))))
+    `(lazy-highlight-face           ((t (:foreground ,gruvbox-black :background ,gruvbox-neutral_yellow))))
+    `(isearch-fail                  ((t (:foreground ,gruvbox-light0 :background ,gruvbox-bright_red))))
 
     ;; anzu-mode
     `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold))))
-    ;`(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
-    ;`(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
-    ;`(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
+    `(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
+    `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
+    `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
     `(anzu-replace-highlight ((t (:inherit isearch)))))
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -367,9 +367,9 @@
 
     ;; anzu-mode
     `(anzu-mode-line        ((t (:foreground ,gruvbox-bright_yellow :weight bold))))
-    `(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
-    `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
-    `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
+    ;`(anzu-match-1          ((t (:background ,gruvbox-bright_green))))
+    ;`(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
+    ;`(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
     `(anzu-replace-highlight ((t (:inherit isearch)))))
 


### PR DESCRIPTION
Two new custom face for show-paren-mode, tries to replicate vim-gruvbox MatchParen
![screenshot from 2016-09-16 16-20-46](https://cloud.githubusercontent.com/assets/1885156/18584994/91cacf8c-7c29-11e6-9a01-c03d5b2f43cf.png)
