### PR TITLE
Adding two show-pren specific colors

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -372,7 +372,12 @@
     `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
     `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
-    `(anzu-replace-highlight ((t (:inherit isearch)))))
+    `(anzu-replace-highlight ((t (:inherit isearch))))
+
+    ;; show-paren
+    `(show-paren-match      ((t (:background ,gruvbox-dark3 :weight bold))))
+    `(show-paren-mismatch   ((t (:background ,gruvbox-bright_red :foreground ,gruvbox-dark3 :weight bold))))
+)
 
 
 (custom-theme-set-variables


### PR DESCRIPTION
show-pren is built-in parenthesis matching mechanism for emacs which
only hasa two faces, show-paren-match and show-paren-mismatch

I used gruvbox-dark3 for show-paren-match to replecate the default
behavior of vim-gruvbox in MatchParen variable.

A bright red back ground used to show mismatched parenthesis.

![screenshot from 2016-09-18 08-21-13](https://cloud.githubusercontent.com/assets/1885156/18612787/e70c5b50-7d78-11e6-9f17-236f8886df6c.png)

![screenshot from 2016-09-18 08-20-48](https://cloud.githubusercontent.com/assets/1885156/18612790/eecab8c8-7d78-11e6-8722-de307356c8eb.png)
