### PR TITLE
 Adding ace-jump and ace-window specific faces

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -372,7 +372,16 @@
     `(anzu-match-2          ((t (:background ,gruvbox-faded_yellow))))
     `(anzu-match-3          ((t (:background ,gruvbox-aquamarine4))))
     `(anzu-replace-to       ((t (:foreground ,gruvbox-bright_yellow))))
-    `(anzu-replace-highlight ((t (:inherit isearch)))))
+    `(anzu-replace-highlight ((t (:inherit isearch))))
+
+    ;; Ace-jump-mode
+    `(ace-jump-face-background  ((t (:foreground ,gruvbox-light4 :background ,gruvbox-bg :inverse-video nil))))
+    `(ace-jump-face-foreground  ((t (:foreground ,gruvbox-bright_red :background ,gruvbox-bg :inverse-video nil :box 1))))
+
+    ;; Ace-window
+    `(aw-background-face        ((t (:forground  ,gruvbox-light1 :background ,gruvbox-bg :inverse-video nil))))
+    `(aw-leading-char-face ((t (:foreground ,gruvbox-bright_orange :background ,gruvbox-bg :height 4.0 :box 1))))
+    )
 
 
 (custom-theme-set-variables

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -380,7 +380,7 @@
 
     ;; Ace-window
     `(aw-background-face        ((t (:forground  ,gruvbox-light1 :background ,gruvbox-bg :inverse-video nil))))
-    `(aw-leading-char-face ((t (:foreground ,gruvbox-bright_orange :background ,gruvbox-bg :height 4.0 :box 1))))
+    `(aw-leading-char-face ((t (:foreground ,gruvbox-bright_orange :background ,gruvbox-bg :height 4.0 :box (:line-width 1 :color ,gruvbox-bright_orange)))))
     )
 
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -381,6 +381,7 @@
     ;; Ace-window
     `(aw-background-face        ((t (:forground  ,gruvbox-light1 :background ,gruvbox-bg :inverse-video nil))))
     `(aw-leading-char-face ((t (:foreground ,gruvbox-bright_orange :background ,gruvbox-bg :height 4.0 :box (:line-width 1 :color ,gruvbox-bright_orange)))))
+    
     ;; show-paren
     `(show-paren-match      ((t (:background ,gruvbox-dark3 :weight bold))))
     `(show-paren-mismatch   ((t (:background ,gruvbox-bright_red :foreground ,gruvbox-dark3 :weight bold))))


### PR DESCRIPTION
ace-jump-mode is one of the frequently used packages to jump to a head
character in current buffer, though it's being replaced by newer
avy-mode, but it still is being used widely

https://github.com/winterTTr/ace-jump-mode

![screenshot from 2016-09-18 09-19-05](https://cloud.githubusercontent.com/assets/1885156/18612955/fbd35900-7d80-11e6-8833-eb5d8f95a5f5.png)


ace-window is a package for selecting a window to switch to, a bright
orange foreground in a box with height ratio of 4 is used to indicate
window numbers in ace-window mode

https://github.com/abo-abo/ace-window

![screenshot from 2016-09-18 09-18-51](https://cloud.githubusercontent.com/assets/1885156/18612956/077af006-7d81-11e6-9d9b-ce11f2a2ba16.png)


