### PR TITLE
added support for 'linum-highlight-face'

### DIFF
--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -187,6 +187,9 @@
   ;; Highlight indentation mode
   (highlight-indentation-current-column-face (:background gruvbox-dark2))
   (highlight-indentation-face                (:background gruvbox-dark1))
+  
+  ;; Highlight linum
+  (linum-highlight-face                      (:background gruvbox-dark1 :foreground gruvbox-neutral_yellow))
 
   ;; Smartparens
   (sp-pair-overlay-face                      (:background gruvbox-dark2))


### PR DESCRIPTION
This will customize the face exposed by the ```hlinum``` package. The result will look like this:

![hlium-gruvbox](http://drop.bryan.codes/ev2PfIB6oF.png)

Basically it provides the same face settings as the standard line highlight to the currently selected line number.

Thanks!