### PR TITLE
Explicitly disabled underline for popup faces

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -173,10 +173,10 @@
      (js2-jsdoc-html-tag-delimiter              (:background nil :foreground gruvbox-light3))
 
      ;; popup
-     (popup-face                                (:foreground gruvbox-light1 :background gruvbox-dark1))
-     (popup-menu-mouse-face                     (:foreground gruvbox-light0 :background gruvbox-faded_green))
-     (popup-menu-selection-face                 (:foreground gruvbox-light0 :background gruvbox-faded_green))
-     (popup-tip-face                            (:foreground gruvbox-light2 :background gruvbox-dark2))
+     (popup-face                                (:underline nil :foreground gruvbox-light1 :background gruvbox-dark1))
+     (popup-menu-mouse-face                     (:underline nil :foreground gruvbox-light0 :background gruvbox-faded_green))
+     (popup-menu-selection-face                 (:underline nil :foreground gruvbox-light0 :background gruvbox-faded_green))
+     (popup-tip-face                            (:underline nil :foreground gruvbox-light2 :background gruvbox-dark2))
 
      ;; helm
      (helm-M-x-key                              (:foreground gruvbox-neutral_orange ))


### PR DESCRIPTION
This fixes an issue with popup menu entries overlapped faces with an underline

This is what happens in the current version of gruvbox when using the auto-complete package

![underline1](https://user-images.githubusercontent.com/22380358/27726679-ae74bb96-5d7b-11e7-9e80-d5b148911c02.png)

This is what it looks like after this patch

![underline2](https://user-images.githubusercontent.com/22380358/27726720-d6c98770-5d7b-11e7-9af4-91758708b944.png)

