### PR TITLE
Removing box styles from ace-jump and ace-window faces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .sass-cache
 /.DS_Store
 /palette/node_modules
+*~
+\#*\#

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -347,11 +347,11 @@
 
      ;; Ace-jump-mode
      (ace-jump-face-background                  (:foreground gruvbox-light4 :background gruvbox-bg :inverse-video nil))
-     (ace-jump-face-foreground                  (:foreground gruvbox-bright_red :background gruvbox-bg :inverse-video nil :box 1))
+     (ace-jump-face-foreground                  (:foreground gruvbox-bright_red :background gruvbox-bg :inverse-video nil))
 
      ;; Ace-window
      (aw-background-face                        (:forground  gruvbox-light1 :background gruvbox-bg :inverse-video nil))
-     (aw-leading-char-face                      (:foreground gruvbox-bright_orange :background gruvbox-bg :height 4.0 :box (:line-width 1 :color gruvbox-bright_orange)))
+     (aw-leading-char-face                      (:foreground gruvbox-bright_red :background gruvbox-bg :height 4.0))
 
      ;; show-paren
      (show-paren-match                          (:background gruvbox-dark3 :weight 'bold))


### PR DESCRIPTION
In my initial pull request I added box around ace-jump and ace-window letters, which at the time I thought was a good idea (it merged to the upstream), after using it for some times and seeing how it annoyingly changes the layout of whole text, now I think it's a good Idea to just see head letters in ace-jump without any boxes.
I also changed ace-window face to gruvbox-bright_red to be consistent with ace-window
and also added two line to .gitignore for Emacs backup files ~* & #*# for folks like myself who always clutter their working directory with those junks.