### PR TITLE
Add some faces to company-mode and Theme tooltips

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -238,10 +238,18 @@
      (company-scrollbar-fg                      (:background gruvbox-dark0_soft))
      (company-tooltip                           (:background gruvbox-dark0_soft))
      (company-tooltip-annotation                (:foreground gruvbox-neutral_green))
-     (company-tooltip-selection                 (:foreground gruvbox-neutral_purple))
+     (company-tooltip-annotation-selection      (:inherit 'company-tooltip-annotation))
+     (company-tooltip-selection                 (:foreground gruvbox-neutral_purple :background gruvbox-dark2))
      (company-tooltip-common                    (:foreground gruvbox-neutral_blue :underline t))
      (company-tooltip-common-selection          (:foreground gruvbox-neutral_blue :underline t))
-     (company-preview-common                    (:foreground gruvbox-neutral_purple))
+     (company-preview-common                    (:foreground gruvbox-light0))
+     (company-preview                           (:background gruvbox-lightblue4))
+     (company-preview-search                    (:background gruvbox-turquoise4))
+     (company-template-field                    (:foreground gruvbox-black :background gruvbox-neutral_yellow))
+     (company-echo-common                       (:foreground gruvbox-faded_red))
+
+     ;; Tool Tips
+     (tooltip                                   (:foreground gruvbox-light1 :background gruvbox-dark1))
 
      ;; Term
      (term-color-black                          (:foreground gruvbox-dark2 :background gruvbox-dark1))


### PR DESCRIPTION
I added some faces to company, where company-preview was using default blue like this
![companypreviewbefore](https://user-images.githubusercontent.com/1885156/27995681-03c21132-64c2-11e7-9770-2982d6a76db1.png)

After change it uses lightblue4 as background and light0 as foreground
After change in dark theme
![companypreviewafter2](https://user-images.githubusercontent.com/1885156/27995699-2df55478-64c2-11e7-94a8-5b0563b77b17.png)

After change in light theme
![companypreviewafter3](https://user-images.githubusercontent.com/1885156/27995705-4b0b2452-64c2-11e7-82e0-fbc1d31233c9.png)

Also company previews were using default yellow like this:
![companytemplatebefore](https://user-images.githubusercontent.com/1885156/27995711-743b44e2-64c2-11e7-9e69-b4e877e59efb.png)

I changed background to neutral_yellow and foreground to gruvbox-black
dark theme
![companytemplateafter](https://user-images.githubusercontent.com/1885156/27995717-99e5d77a-64c2-11e7-890c-81543c74d407.png)

light theme
![screenshot from 2017-07-09 19-35-42](https://user-images.githubusercontent.com/1885156/27995719-a428c652-64c2-11e7-8404-14d2de911474.png)

Also tooltips had no theme
![tooltipafter1](https://user-images.githubusercontent.com/1885156/27995734-d7133070-64c2-11e7-8080-120034dc4925.png)
![tooltipafter2](https://user-images.githubusercontent.com/1885156/27995735-daf4c32a-64c2-11e7-83d4-82e0c8f1a1cf.png)







