### PR TITLE
Added widget faces

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -452,6 +452,12 @@
      (undo-tree-visualizer-register-face        (:foreground gruvbox-bright_yellow))
      (undo-tree-visualizer-unmodified-face      (:foreground gruvbox-bright_aqua))
 
+     ;; Widget faces
+     (widget-button-pressed-face                (:foreground gruvbox-bright_red))
+     (widget-documentation-face                 (:foreground gruvbox-faded_green))
+     (widget-field                              (:foreground gruvbox-light0 :background gruvbox-dark2))
+     (widget-single-line-field                  (:foreground gruvbox-light0 :background gruvbox-dark2))
+
      ;; MODE SUPPORT: dired+
      (diredp-file-name                          (:foreground gruvbox-light2))
      (diredp-file-suffix                        (:foreground gruvbox-light4))


### PR DESCRIPTION
Left side of screen in emacs running in a 256-color terminal, right side is GUI emacs.

Dark Theme
![dark_before](https://user-images.githubusercontent.com/22380358/28133634-f0a7cad4-6740-11e7-8f01-2b9f120f79cf.png)

![dark_after](https://user-images.githubusercontent.com/22380358/28133632-f08bf75a-6740-11e7-9fb8-3c76d3148731.png)

Light theme
![light_before](https://user-images.githubusercontent.com/22380358/28133636-f0aeb79a-6740-11e7-8cd1-cf589c45cc28.png)

![light_after](https://user-images.githubusercontent.com/22380358/28133635-f0ad50e4-6740-11e7-96aa-2b633cd7255b.png)
