### PR TITLE
Updated linum faces and added suport for native line numbers

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -72,7 +72,6 @@
      (mode-line                                 (:background gruvbox-dark2 :foreground gruvbox-light2 :box nil))
      (mode-line-inactive                        (:background gruvbox-dark1 :foreground gruvbox-light4 :box nil))
      (fringe                                    (:background gruvbox-bg))
-     (linum                                     (:background gruvbox-bg :foreground gruvbox-dark4))
      (hl-line                                   (:background gruvbox-dark1))
      (region                                    (:background gruvbox-dark2)) ;;selection
 
@@ -134,15 +133,17 @@
      (rainbow-delimiters-depth-12-face          (:foreground gruvbox-delimiter-four))
      (rainbow-delimiters-unmatched-face         (:background nil :foreground gruvbox-light0))
 
-     ;; linum-relative
-     (linum-relative-current-face               (:background gruvbox-dark1 :foreground gruvbox-light4))
+
+     ;; line numbers
+     (line-number                               (:foreground gruvbox-dark2 :background gruvbox-dark0))
+     (line-number-current-line                  (:foreground gruvbox-neutral_orange :background gruvbox-dark1))
+     (linum                                     (:inherit 'line-number))
+     (linum-highlight-face                      (:inherit 'line-number-current-line))
+     (linum-relative-current-face               (:inherit 'line-number-current-line))
 
      ;; Highlight indentation mode
      (highlight-indentation-current-column-face (:background gruvbox-dark2))
      (highlight-indentation-face                (:background gruvbox-dark1))
-
-     ;; Highlight linum
-     (linum-highlight-face                      (:background gruvbox-dark1 :foreground gruvbox-neutral_yellow))
 
      ;; Smartparens
      (sp-pair-overlay-face                      (:background gruvbox-dark2))


### PR DESCRIPTION
Fix for https://github.com/greduan/emacs-theme-gruvbox/issues/83

![linenumber_light](https://user-images.githubusercontent.com/22380358/28266391-e0d24974-6af4-11e7-9032-54572176bd52.png)
![linenumber_dark](https://user-images.githubusercontent.com/22380358/28266397-ea9adfca-6af4-11e7-90ac-ce2804699831.png)

Linum faces now inherit from the native line number faces