### PR TITLE
Added support for sh-quoted-exec and sh-heredoc

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -446,6 +446,10 @@
      (mu4e-unread-face                          (:foreground gruvbox-bright_blue :weight 'bold ))
      (mu4e-highlight-face                       (:foreground gruvbox-neutral_green))
 
+     ;; Shell script faces
+     (sh-quoted-exec                            (:foreground gruvbox-bright_purple))
+     (sh-heredoc                                (:foreground gruvbox-bright_orange))
+
      ;; Undo-tree
      (undo-tree-visualizer-active-branch-face   (:foreground gruvbox-light0))
      (undo-tree-visualizer-current-face         (:foreground gruvbox-bright_red))


### PR DESCRIPTION
Colors were chosen to match the gruvbox pallete while still being
similar to their unthemed colors.

Screenshots of changes below

Dark theme:
![sh_before_dark](https://user-images.githubusercontent.com/22380358/28308288-03b0c932-6ba6-11e7-992b-79171e796d94.png)
![sh_after_dark](https://user-images.githubusercontent.com/22380358/28308328-1f8b7eea-6ba6-11e7-835b-ea1f49ed7062.png)


Light them:

![sh_before_light](https://user-images.githubusercontent.com/22380358/28308287-039f90f4-6ba6-11e7-9af6-65abda0f038b.png)
![sh_after_light](https://user-images.githubusercontent.com/22380358/28308332-22f78f88-6ba6-11e7-8acb-2d722d0d740c.png)
