### PR TITLE
Fixed issue with eshell faces not being recognized

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.1
+;; Version: 1.22.2
 
 ;; Package-Requires: ((autothemer "0.2"))
 
@@ -529,17 +529,17 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
 
      ;; eshell
      (eshell-prompt-face                         (:foreground gruvbox-bright_aqua))
-     (eshell-ls-archive-face                     (:foreground gruvbox-light0 :weight 'bold))
-     (eshell-ls-backup-face                      (:inherit 'dired-ignored-face))
+     (eshell-ls-archive-face                     (:foreground gruvbox-light3))
+     (eshell-ls-backup-face                      (:foreground gruvbox-light4))
      (eshell-ls-clutter-face                     (:foreground gruvbox-bright_orange :weight 'bold))
-     (eshell-ls-directory-face                   (:inherit 'dired-directory-face))
+     (eshell-ls-directory-face                   (:foreground gruvbox-bright_yellow))
      (eshell-ls-executable-face                  (:weight 'bold))
-     (eshell-ls-missing-face                     (:inherit 'dired-warning-face))
+     (eshell-ls-missing-face                     (:foreground gruvbox-bright_red :bold t))
      (eshell-ls-product-face                     (:foreground gruvbox-faded_red))
-     (eshell-ls-readonly-face                    (:inherit 'dired-perm-write-face))
-     (eshell-ls-special-face                     (:inherit 'dired-marked-face))
-     (eshell-ls-symlink-face                     (:inherit 'dired-symlink-face))
-     (eshell-ls-unreadable-face                  (:inherit 'dired-warning-face)))
+     (eshell-ls-readonly-face                    (:foreground gruvbox-light2))
+     (eshell-ls-special-face                     (:foreground gruvbox-bright_yellow :bold t))
+     (eshell-ls-symlink-face                     (:foreground gruvbox-bright_red))
+     (eshell-ls-unreadable-face                  (:foreground gruvbox-bright_red :bold t)))
     ,@body))
 
 (provide 'gruvbox)


### PR DESCRIPTION
In commit https://github.com/greduan/emacs-theme-gruvbox/commit/b6d93d25faff573a7f7712bc33fce1fe422473e0 an issue was fixed with loading the faces for eshell. 

Unfortunately with this commit all (inheriting) eshell faces now look the same (White on black for dark themes, black on white for light themes).

![eshell1-gruvbox-dark-hard](https://user-images.githubusercontent.com/22380358/32980121-220a65f2-cc61-11e7-9561-2539a90ef437.png)

This fixed that by defining specific colors instead of relying on inheritance.

![eshell2-gruvbox-dark-hard](https://user-images.githubusercontent.com/22380358/32980123-260b216e-cc61-11e7-8390-1f68913635ea.png)

