### PR TITLE
Increased visibility of matching parenthises and line numbers

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -12,7 +12,7 @@
 ;;              Greduan <me@greduan.com>
 ;;
 ;; URL: http://github.com/Greduan/emacs-theme-gruvbox
-;; Version: 1.22.2
+;; Version: 1.22.3
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -155,11 +155,11 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
 
 
      ;; line numbers
-     (line-number                               (:foreground gruvbox-dark2 :background gruvbox-dark0))
-     (line-number-current-line                  (:foreground gruvbox-bright_orange :background gruvbox-dark1))
-     (linum                                     (:foreground gruvbox-dark2 :background gruvbox-dark0))
-     (linum-highlight-face                      (:foreground gruvbox-bright_orange :background gruvbox-dark1))
-     (linum-relative-current-face               (:foreground gruvbox-bright_orange :background gruvbox-dark1))
+     (line-number                               (:foreground gruvbox-dark4 :background gruvbox-dark1))
+     (line-number-current-line                  (:foreground gruvbox-bright_orange :background gruvbox-dark2))
+     (linum                                     (:foreground gruvbox-dark4 :background gruvbox-dark1))
+     (linum-highlight-face                      (:foreground gruvbox-bright_orange :background gruvbox-dark2))
+     (linum-relative-current-face               (:foreground gruvbox-bright_orange :background gruvbox-dark2))
 
      ;; Highlight indentation mode
      (highlight-indentation-current-column-face (:background gruvbox-dark2))

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -395,7 +395,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (aw-leading-char-face                      (:foreground gruvbox-bright_red :background gruvbox-bg :height 4.0))
 
      ;; show-paren
-     (show-paren-match                          (:background gruvbox-dark3 :weight 'bold))
+     (show-paren-match                          (:background gruvbox-dark3 :foreground gruvbox-bright_blue  :weight 'bold))
      (show-paren-mismatch                       (:background gruvbox-bright_red :foreground gruvbox-dark3 :weight 'bold))
 
      ;; ivy


### PR DESCRIPTION
This fixes the issues of https://github.com/greduan/emacs-theme-gruvbox/issues/108

Old contrast of the line numbers was a bit low, most noticeably on the dark-hard and light-hard variants of the theme.

The paren match face was far more subtle than other themes. It was easily visible with the default background but was hard to see when combine with hl-line-mode.

Screenshots of new faces (with line numbers and hl-line-mode enabled):

![hl-line-match](https://user-images.githubusercontent.com/22380358/35967468-42ab600e-0cc1-11e8-9b8c-ead9c9ec5883.png)
![hl-line-mismatch](https://user-images.githubusercontent.com/22380358/35967479-4be358ac-0cc1-11e8-9b3a-5bfc7024c914.png)

Screenshots with paren face mode (A mode I personally use which normally dims the parenthesis):

![personal-match](https://user-images.githubusercontent.com/22380358/35967713-06fa9574-0cc2-11e8-8e9b-6267eaca8ae2.png)

![personal-mismatch](https://user-images.githubusercontent.com/22380358/35967740-16a7ebfc-0cc2-11e8-845c-7eaf3a3c5890.png)

