### PR TITLE
Added support for which-function-mode

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -12,7 +12,7 @@
 ;;              Eduardo Lavaque <me@greduan.com>
 ;;
 ;; URL: http://github.com/greduan/emacs-theme-gruvbox
-;; Version: 1.22.3
+;; Version: 1.23.0
 
 ;; Package-Requires: ((autothemer "0.2"))
 
@@ -539,7 +539,10 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (eshell-ls-readonly-face                    (:foreground gruvbox-light2))
      (eshell-ls-special-face                     (:foreground gruvbox-bright_yellow :bold t))
      (eshell-ls-symlink-face                     (:foreground gruvbox-bright_red))
-     (eshell-ls-unreadable-face                  (:foreground gruvbox-bright_red :bold t)))
+     (eshell-ls-unreadable-face                  (:foreground gruvbox-bright_red :bold t))
+
+     ;; which-function-mode
+     (which-func                                 (:foreground gruvbox-faded_blue)))
     ,@body))
 
 (provide 'gruvbox)


### PR DESCRIPTION
In response to https://github.com/greduan/emacs-theme-gruvbox/issues/112

The func-mode face is changed from the default drab blue to the bright-blue in the gruvbox palletes.

![1520958851-window](https://user-images.githubusercontent.com/22380358/37356600-ac81f058-26e6-11e8-8384-9b25c4ba23ce.png)
![1520958866-window](https://user-images.githubusercontent.com/22380358/37356601-acada93c-26e6-11e8-81f0-184502cd5362.png)
