### PR TITLE
Use lexical binding and fix typo/unused colors and arguments

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -69,7 +69,6 @@
 
   (gruvbox-light0_hard     "#ffffc8" "#ffffd7")
   (gruvbox-light0          "#fdf4c1" "#ffffaf")
-  (gruvbox-light0_soft     "#f4e8ba" "#ffffaf")
   (gruvbox-light1          "#ebdbb2" "#ffdfaf")
   (gruvbox-light2          "#d5c4a1" "#bcbcbc")
   (gruvbox-light3          "#bdae93" "#a8a8a8")
@@ -102,7 +101,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-dark-hard-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-dark-hard-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -57,7 +57,6 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
-  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -69,7 +68,6 @@
 
   (gruvbox-light0_hard     "#ffffc8" "#ffffd7")
   (gruvbox-light0          "#fdf4c1" "#ffffaf")
-  (gruvbox-light0_soft     "#f4e8ba" "#ffffaf")
   (gruvbox-light1          "#ebdbb2" "#ffdfaf")
   (gruvbox-light2          "#d5c4a1" "#bcbcbc")
   (gruvbox-light3          "#bdae93" "#a8a8a8")
@@ -102,7 +100,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-dark-medium-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-dark-medium-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-dark-soft-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-dark-soft-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -57,7 +57,6 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
-  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -69,7 +68,6 @@
 
   (gruvbox-light0_hard     "#ffffc8" "#ffffd7")
   (gruvbox-light0          "#fdf4c1" "#ffffaf")
-  (gruvbox-light0_soft     "#f4e8ba" "#ffffaf")
   (gruvbox-light1          "#ebdbb2" "#ffdfaf")
   (gruvbox-light2          "#d5c4a1" "#bcbcbc")
   (gruvbox-light3          "#bdae93" "#a8a8a8")
@@ -102,7 +100,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-light-hard-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-light-hard-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -69,7 +69,6 @@
 
   (gruvbox-light0_hard     "#1d2021" "#1c1c1c")
   (gruvbox-light0          "#282828" "#262626")
-  (gruvbox-light0_soft     "#32302f" "#303030")
   (gruvbox-light1          "#3c3836" "#3a3a3a")
   (gruvbox-light2          "#504945" "#4e4e4e")
   (gruvbox-light3          "#665c54" "#626262")
@@ -102,7 +101,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-light-medium-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-light-medium-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -57,7 +57,6 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
-  (gruvbox-dark0_hard      "#f9f5d7" "#ffffd7")
   (gruvbox-dark0           "#fbf1c7" "#ffffd7")
   (gruvbox-dark0_soft      "#f2e5bc" "#ffffd7")
   (gruvbox-dark1           "#ebdbb2" "#ffffaf")
@@ -69,7 +68,6 @@
 
   (gruvbox-light0_hard     "#1d2021" "#1c1c1c")
   (gruvbox-light0          "#282828" "#262626")
-  (gruvbox-light0_soft     "#32302f" "#303030")
   (gruvbox-light1          "#3c3836" "#3a3a3a")
   (gruvbox-light2          "#504945" "#4e4e4e")
   (gruvbox-light3          "#665c54" "#626262")
@@ -102,7 +100,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -58,7 +58,6 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
-  (gruvbox-dark0_hard      "#f9f5d7" "#ffffd7")
   (gruvbox-dark0           "#fbf1c7" "#ffffd7")
   (gruvbox-dark0_soft      "#f2e5bc" "#ffffd7")
   (gruvbox-dark1           "#ebdbb2" "#ffffaf")
@@ -70,7 +69,6 @@
 
   (gruvbox-light0_hard     "#1d2021" "#1c1c1c")
   (gruvbox-light0          "#282828" "#262626")
-  (gruvbox-light0_soft     "#32302f" "#303030")
   (gruvbox-light1          "#3c3836" "#3a3a3a")
   (gruvbox-light2          "#504945" "#4e4e4e")
   (gruvbox-light3          "#665c54" "#626262")
@@ -103,7 +101,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvbox-darkslategray4  "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -1,4 +1,5 @@
-;;; gruvbox-light-soft-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-light-soft-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
+
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -1,4 +1,4 @@
-;;; gruvbox-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -57,7 +57,6 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
-  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -69,7 +68,6 @@
 
   (gruvbox-light0_hard     "#ffffc8" "#ffffd7")
   (gruvbox-light0          "#fdf4c1" "#ffffaf")
-  (gruvbox-light0_soft     "#f4e8ba" "#ffffaf")
   (gruvbox-light1          "#ebdbb2" "#ffdfaf")
   (gruvbox-light2          "#d5c4a1" "#bcbcbc")
   (gruvbox-light3          "#bdae93" "#a8a8a8")
@@ -89,7 +87,6 @@
   (gruvbox-neutral_blue    "#83a598" "#87afaf")
   (gruvbox-neutral_purple  "#d3869b" "#d787af")
   (gruvbox-neutral_aqua    "#8ec07c" "#87af87")
-  (gruvbox-neutral_orange  "#fe8019" "#ff8700")
 
   (gruvbox-faded_red       "#9d0006" "#870000")
   (gruvbox-faded_green     "#79740e" "#878700")
@@ -110,7 +107,6 @@
   (gruvbox-white           "#FFFFFF" "#FFFFFF")
   (gruvbox-black           "#000000" "#000000")
   (gruvbox-sienna          "#DD6F48" "#d7875f")
-  (gruvboxslategray4       "#528B8B" "#5f8787")
   (gruvbox-lightblue4      "#66999D" "#5fafaf")
   (gruvbox-burlywood4      "#BBAA97" "#afaf87")
   (gruvbox-aquamarine4     "#83A598" "#87af87")

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -120,7 +120,7 @@
 
  (custom-theme-set-variables 'gruvbox
                              `(ansi-color-names-vector
-                               [,gruvbox1
+                               [,gruvbox-dark1
                                 ,gruvbox-neutral_red
                                 ,gruvbox-neutral_green
                                 ,gruvbox-neutral_yellow

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -1,4 +1,4 @@
-;;; gruvbox-dark-theme.el --- A retro-groove colour theme for Emacs
+;;; gruvbox-dark-theme.el --- A retro-groove colour theme for Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Lee Machin
 ;; Copyright (c) 2013-2016 Eduardo Lavaque

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -82,7 +82,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
     (shell-command (format gruvbox-screenshot-command
                            prefix theme))))
 
-(defmacro gruvbox-deftheme (name description palette reduced-specs &rest body)
+(defmacro gruvbox-deftheme (name description palette &rest body)
   `(autothemer-deftheme
     ,name
     ,description


### PR DESCRIPTION
Using lexical binding it is easier to spot mistakes, e.g. `gruvbox1` color was not defined anywhere, it was probably meant to be `gruvbox-dark1`.
By using a [patched autothemer](https://github.com/sebastiansturm/autothemer/pull/12) I also found and removed some unused colors.