### PR TITLE
Support pdf-view-midnight-minor-mode

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -117,7 +117,8 @@
                                 ,gruvbox-bright_blue
                                 ,gruvbox-bright_purple
                                 ,gruvbox-bright_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -116,7 +116,8 @@
                                 ,gruvbox-bright_blue
                                 ,gruvbox-bright_purple
                                 ,gruvbox-bright_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -116,7 +116,8 @@
                                 ,gruvbox-bright_blue
                                 ,gruvbox-bright_purple
                                 ,gruvbox-bright_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -117,7 +117,8 @@
                                 ,gruvbox-faded_blue
                                 ,gruvbox-faded_purple
                                 ,gruvbox-faded_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -116,7 +116,8 @@
                                 ,gruvbox-faded_blue
                                 ,gruvbox-faded_purple
                                 ,gruvbox-faded_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -117,7 +117,8 @@
                                 ,gruvbox-bright_blue
                                 ,gruvbox-bright_purple
                                 ,gruvbox-bright_aqua
-                                ,gruvbox-light1])))
+                                ,gruvbox-light1])
+			     `(pdf-view-midnight-colors '(,gruvbox-light0 . ,gruvbox-bg))))
 
 ;;;###autoload
 (and load-file-name


### PR DESCRIPTION
The `pdf-tools` package has a `pdf-view-midnight-minor-mode` with bright text on dark background. Using `gruvbox` colors makes it look nicer.
The screenshots are here, however, other colors may be more beautiful.

![gruvbox-dark-soft](https://user-images.githubusercontent.com/10540480/46904995-b573c880-cf1f-11e8-99d1-9b2d000f1d45.png)
`gruvbox-dark-soft`
![gruvbox-light-soft](https://user-images.githubusercontent.com/10540480/46905024-ff5cae80-cf1f-11e8-9d9b-1edcb7553b71.png)
`gruvbox-light-soft`
