### PR TITLE
Add support for auto-dim-other-buffers.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This theme contains custom support for the following features and plugins:
 - Ace jump
 - Ace window
 - [Anzu](https://github.com/syohex/emacs-anzu#customization)
+- [Auto-dim-other-buffers](https://github.com/mina86/auto-dim-other-buffers.el)
 - Comint (and the like)
 - Company
 - Diffs

--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -106,7 +106,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0_hard))
+  (gruvbox-bg gruvbox-dark0_hard)
+  (gruvbox-bg_inactive gruvbox-dark0)
+  )
 
  (custom-theme-set-variables 'gruvbox-dark-hard
                              `(ansi-color-names-vector

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -57,6 +57,7 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
+  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -105,7 +106,10 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0))
+  (gruvbox-bg gruvbox-dark0)
+  (gruvbox-bg_inactive gruvbox-dark0_soft)
+  )
+ 
 
  (custom-theme-set-variables 'gruvbox-dark-medium
                              `(ansi-color-names-vector

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -57,6 +57,7 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
+  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -105,7 +106,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0_soft))
+  (gruvbox-bg gruvbox-dark0_soft)
+  (gruvbox-bg_inactive gruvbox-dark1)
+  )
 
  (custom-theme-set-variables 'gruvbox-dark-soft
                              `(ansi-color-names-vector

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -106,7 +106,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0_hard))
+  (gruvbox-bg gruvbox-dark0_hard)
+  (gruvbox-bg_inactive gruvbox-dark0)
+  )
 
  (custom-theme-set-variables 'gruvbox-light-hard
                              `(ansi-color-names-vector

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -57,6 +57,7 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
+  (gruvbox-dark0_hard      "#f9f5d7" "#ffffd7")
   (gruvbox-dark0           "#fbf1c7" "#ffffd7")
   (gruvbox-dark0_soft      "#f2e5bc" "#ffffd7")
   (gruvbox-dark1           "#ebdbb2" "#ffffaf")
@@ -105,7 +106,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0))
+  (gruvbox-bg gruvbox-dark0)
+  (gruvbox-bg_inactive gruvbox-dark0_soft)
+  )
 
  (custom-theme-set-variables 'gruvbox-light-medium
                              `(ansi-color-names-vector

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -58,6 +58,7 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
+  (gruvbox-dark0_hard      "#f9f5d7" "#ffffd7")
   (gruvbox-dark0           "#fbf1c7" "#ffffd7")
   (gruvbox-dark0_soft      "#f2e5bc" "#ffffd7")
   (gruvbox-dark1           "#ebdbb2" "#ffffaf")
@@ -106,7 +107,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0_soft))
+  (gruvbox-bg gruvbox-dark0_soft)
+  (gruvbox-bg_inactive gruvbox-dark1)
+  )
 
  (custom-theme-set-variables 'gruvbox-light-soft
                              `(ansi-color-names-vector

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -57,6 +57,7 @@
  ((((class color) (min-colors #xFFFFFF))        ; col 1 GUI/24bit
    ((class color) (min-colors #xFF)))           ; col 2 Xterm/256
 
+  (gruvbox-dark0_hard      "#1d2021" "#1c1c1c")
   (gruvbox-dark0           "#282828" "#262626")
   (gruvbox-dark0_soft      "#32302f" "#303030")
   (gruvbox-dark1           "#3c3836" "#3a3a3a")
@@ -112,7 +113,9 @@
   (gruvbox-aquamarine4     "#83A598" "#87af87")
   (gruvbox-turquoise4      "#61ACBB" "#5fafaf")
 
-  (gruvbox-bg gruvbox-dark0))
+  (gruvbox-bg gruvbox-dark0)
+  (gruvbox-bg_inactive gruvbox-dark0_soft)
+  )
 
  (custom-theme-set-variables 'gruvbox
                              `(ansi-color-names-vector

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -601,7 +601,11 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (hydra-face-teal (:foreground gruvbox-bright_aqua :weight 'bold))
 
      ;; which-function-mode
-     (which-func                                 (:foreground gruvbox-faded_blue)))
+     (which-func                                 (:foreground gruvbox-faded_blue))
+
+     ;; auto-dim-other-buffers
+     (auto-dim-other-buffers-face                (:background gruvbox-bg_inactive))
+     )
     ,@body))
 
 (provide 'gruvbox)


### PR DESCRIPTION
`auto-dim-other-buffers.el` is a minor mode that provides a visual
distinction between active and inactive buffers by modifying face
attributes. The source code for auto-dim-other-buffers.el is available
at https://github.com/mina86/auto-dim-other-buffers.el.

In order to implement support for `auto-dim-other-buffers.el` in the
gruvbox theme, this commit introduces, in addition to the `gruvbox-bg`
colour that contains the background colour under the current theme, a
secondary `gruvbox-bg_inactive` colour that is always one level
softer. In this way, `auto-dim-other-buffers.el` with gruvbox provides a
subtle indication of active and inactive buffers, where inactive
buffers have minimally lower contrast.

In addition, this commit harmonizes the colour definitions among the
soft, hard and medium flavours so that every flavour provides the full
set of `dark0_hard`, `dark0` and `dark0_soft` variant colours for theming.