### PR TITLE
Add faces for neotree

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This theme contains custom support for the following features and plugins:
 - Magit
 - Markdown
 - Message
+- [Neotree](https://github.com/jaypei/emacs-neotree)
 - Org
 - Popup
 - [RainbowDelimiters](http://www.emacswiki.org/emacs/RainbowDelimiters)

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -567,6 +567,14 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (diredp-read-priv                          (:foreground gruvbox-bright_red  :background gruvbox-dark_red))
      (diredp-write-priv                         (:foreground gruvbox-bright_aqua :background gruvbox-dark_aqua))
 
+     ;; neotree
+     (neo-banner-face                           (:foreground gruvbox-bright_purple :bold t))
+     (neo-dir-link-face                         (:foreground gruvbox-bright_yellow))
+     (neo-expand-btn-face                       (:foreground gruvbox-bright_orange))
+     (neo-file-link-face                        (:foreground gruvbox-light0))
+     (neo-header-face                           (:foreground gruvbox-bright_purple))
+     (neo-root-dir-face                         (:inherit neo-banner-face))
+
      ;; eshell
      (eshell-prompt-face                         (:foreground gruvbox-bright_aqua))
      (eshell-ls-archive-face                     (:foreground gruvbox-light3))


### PR DESCRIPTION
Hi there! I've added faces for neotree, mostly inspired by the dired colors. I thought it appropriate since neotree is also displaying files and directories. Here are a couple of screenshots:

<img width="1044" alt="Screen Shot 2019-03-29 at 16 02 21" src="https://user-images.githubusercontent.com/223625/55242038-b46bf480-523c-11e9-9518-ec934e2e4e59.png">

<img width="1044" alt="Screen Shot 2019-03-29 at 16 02 12" src="https://user-images.githubusercontent.com/223625/55242059-bdf55c80-523c-11e9-8b28-53b4dd88c034.png">

I didn't make all the variations since the automated screenshot facility is not working for me at the moment. Hopefully this two are enough, but if not let me know and I can take new ones when I have some time.
