### PR TITLE
Set attributes for neo-root-dir-face directly instead of inheriting

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -573,7 +573,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (neo-expand-btn-face                       (:foreground gruvbox-bright_orange))
      (neo-file-link-face                        (:foreground gruvbox-light0))
      (neo-header-face                           (:foreground gruvbox-bright_purple))
-     (neo-root-dir-face                         (:inherit neo-banner-face))
+     (neo-root-dir-face                         (:foreground gruvbox-bright_purple :bold t))
 
      ;; eshell
      (eshell-prompt-face                         (:foreground gruvbox-bright_aqua))


### PR DESCRIPTION
Fixes an error for users that don't have neotree installed described by @aashiks in #132.

Fixes #133 