### PR TITLE
Add faces for wgrep

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -601,6 +601,13 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (tabbar-selected                            (:inherit 'tabbar-default :foreground gruvbox-bright_yellow))
      (tabbar-selected-modified                   (:inherit 'tabbar-selected))
 
+     ;; wgrep
+     (wgrep-delete-face                          (:strike-through gruvbox-bright_red))
+     (wgrep-done-face                            (:foreground gruvbox-turquoise4))
+     (wgrep-face                                 (:underline (:color gruvbox-bright_yellow :style 'line)))
+     (wgrep-file-face                            (:inherit 'highlight))
+     (wgrep-reject-face                          (:foreground gruvbox-bright_red :bold t))
+
      ;; hydra
      (hydra-face-red (:foreground gruvbox-bright_red :weight 'bold))
      (hydra-face-blue (:foreground gruvbox-bright_blue :weight 'bold))


### PR DESCRIPTION
Hi! Here are some faces for [wgrep](https://github.com/mhayashi1120/Emacs-wgrep), another feature that I use rather frequently. Hopefully useful for others too. No weird inherits here, only one from builtin highlight face, so (hopefully) shouldn't break anything this time :-)

I didn't add it to the README, since it's more of a support feature for grep than a main feature, but I could add it if you think it's appropriate.

Screenshots:

Dark before apply:
![Screenshot 2019-04-01 at 16 56 55](https://user-images.githubusercontent.com/223625/55339649-5f7de780-54a3-11e9-84dc-9f8b7f29dbd2.png)

Dark after apply
![Screenshot 2019-04-01 at 16 57 26](https://user-images.githubusercontent.com/223625/55339693-73294e00-54a3-11e9-8be5-4f0ec6ce310a.png)

Light before apply:
![Screenshot 2019-04-01 at 16 57 03](https://user-images.githubusercontent.com/223625/55339720-83d9c400-54a3-11e9-948c-c02f89c5b24d.png)

Light after apply:
![Screenshot 2019-04-01 at 16 57 17](https://user-images.githubusercontent.com/223625/55339729-89cfa500-54a3-11e9-9641-3a556028dd18.png)
