### PR TITLE
Make some smart-mode-line info visible in light theme

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -374,7 +374,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (elfeed-search-filter-face                 (:inherit 'font-lock-string-face))
 
      ;; smart-mode-line
-     (sml/global                                (:foreground gruvbox-burlywood4 :inverse-video nil))
+     (sml/global                                (:foreground gruvbox-light4 :inverse-video nil))
      (sml/modes                                 (:foreground gruvbox-bright_green))
      (sml/filename                              (:foreground gruvbox-bright_red :weight 'bold))
      (sml/prefix                                (:foreground gruvbox-light1))


### PR DESCRIPTION
Hello :-)

The current color for the sml/global face (used for rendering e.g.
column indicator, minor mode names) is gruvbox-burlywood4. This color
doesn't invert and it's invisible in a focused window when using the
light hard variant.

Before:
<img width="1680" alt="Screen Shot 2019-04-05 at 15 29 46" src="https://user-images.githubusercontent.com/223625/55631942-741af200-57b9-11e9-8123-90fa524fcb58.png">
<img width="1680" alt="Screen Shot 2019-04-05 at 15 29 36" src="https://user-images.githubusercontent.com/223625/55631949-767d4c00-57b9-11e9-8cf8-99e3ea1d3357.png">

After:
<img width="1679" alt="Screen Shot 2019-04-05 at 15 30 37" src="https://user-images.githubusercontent.com/223625/55631961-809f4a80-57b9-11e9-911d-b6aadb47e40b.png">
<img width="1680" alt="Screen Shot 2019-04-05 at 15 30 45" src="https://user-images.githubusercontent.com/223625/55631964-8301a480-57b9-11e9-8c01-21187cd2fd49.png">

This PR fixes this by using gruvbox-light4, which will invert correctly
and display properly in light themes.