### PR TITLE
Add basic theming for tab bar mode

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -640,8 +640,11 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (flycheck-error-list-error                 (:foreground gruvbox-bright_red :bold t))
      (flycheck-error-list-info                  (:foreground gruvbox-bright_blue :bold t))
 
-     )
-    ,@body))
+     ;; tab-bar
+     (tab-bar-tab-inactive (:background gruvbox-bg :foreground gruvbox-light0))
+     (tab-bar-tab (:background gruvbox-dark2 :foreground gruvbox-light0))
+     (tab-bar (:background gruvbox-bg :foreground gruvbox-light0))
+     ),@body))
 
 (provide 'gruvbox)
 


### PR DESCRIPTION
There is a native tab mode on the Emacs master branch now. This update provides some basic theming to keep the visuals in-step with other effects provided by the theme. The active tab is darker (in light modes) or lighter (in dark modes) than other tabs to indicate that it's active, while the rest of the tab line blends in with the background. 
![gruvbox](https://user-images.githubusercontent.com/33698018/66273519-5565e880-e83a-11e9-96c1-a222206c5b44.png)
