### PR TITLE
add neutral tones to dark theme; fix #151

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -82,6 +82,13 @@
   (gruvbox-bright_aqua     "#8ec07c" "#87af87")
   (gruvbox-bright_orange   "#fe8019" "#ff8700")
 
+  (gruvbox-neutral_red     "#fb4934" "#d75f5f")
+  (gruvbox-neutral_green   "#b8bb26" "#afaf00")
+  (gruvbox-neutral_yellow  "#fabd2f" "#ffaf00")
+  (gruvbox-neutral_blue    "#83a598" "#87afaf")
+  (gruvbox-neutral_purple  "#d3869b" "#d787af")
+  (gruvbox-neutral_aqua    "#8ec07c" "#87af87")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")


### PR DESCRIPTION
It turns out neutral colors were not loaded in this theme, but they are now required by Gruvbox, with the new ERC compatibility code.

- `(erc-timestamp-face         (:foreground gruvbox-neutral_green))`

- `(erc-pal-face               (:foreground gruvbox-neutral_yellow :weight 'bold))`

This patch adds the neutral colors and resolves the error I reported earlier. The same idea may need to be replicated across other non-default themes.