### PR TITLE
gruvbox-neutral_orange was missing from gruvbox-theme.el; neutral colors missing more widely

### DIFF
--- a/gruvbox-dark-hard-theme.el
+++ b/gruvbox-dark-hard-theme.el
@@ -88,7 +88,8 @@
   (gruvbox-neutral_blue    "#83a598" "#87afaf")
   (gruvbox-neutral_purple  "#d3869b" "#d787af")
   (gruvbox-neutral_aqua    "#8ec07c" "#87af87")
-
+  (gruvbox-neutral_orange  "#fe8019" "#ff8700")
+  
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-dark-medium-theme.el
+++ b/gruvbox-dark-medium-theme.el
@@ -82,6 +82,14 @@
   (gruvbox-bright_aqua     "#8ec07c" "#87af87")
   (gruvbox-bright_orange   "#fe8019" "#ff8700")
 
+  (gruvbox-neutral_red      "#fb4933" "#d75f5f")
+  (gruvbox-neutral_green    "#b8bb26" "#afaf00")
+  (gruvbox-neutral_yellow   "#fabd2f" "#ffaf00")
+  (gruvbox-neutral_blue     "#83a598" "#87afaf")
+  (gruvbox-neutral_purple   "#d3869b" "#d787af")
+  (gruvbox-neutral_aqua     "#8ec07c" "#87af87")
+  (gruvbox-neutral_orange   "#fe8019" "#ff8700")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-dark-soft-theme.el
+++ b/gruvbox-dark-soft-theme.el
@@ -82,6 +82,14 @@
   (gruvbox-bright_aqua     "#8ec07c" "#87af87")
   (gruvbox-bright_orange   "#fe8019" "#ff8700")
 
+  (gruvbox-neutral_red     "#fb4933" "#d75f5f")
+  (gruvbox-neutral_green   "#b8bb26" "#afaf00")
+  (gruvbox-neutral_yellow  "#fabd2f" "#ffaf00")
+  (gruvbox-neutral_blue    "#83a598" "#87afaf")
+  (gruvbox-neutral_purple  "#d3869b" "#d787af")
+  (gruvbox-neutral_aqua    "#8ec07c" "#87af87")
+  (gruvbox-neutral_orange  "#fe8019" "#ff8700")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-light-hard-theme.el
+++ b/gruvbox-light-hard-theme.el
@@ -82,6 +82,14 @@
   (gruvbox-bright_aqua     "#427b58" "#5f8787")
   (gruvbox-bright_orange   "#af3a03" "#af5f00")
 
+  (gruvbox-neutral_red      "#9d0006" "#870000")
+  (gruvbox-neutral_green    "#79740e" "#878700")
+  (gruvbox-neutral_yellow   "#b57614" "#af8700")
+  (gruvbox-neutral_blue     "#076678" "#005f87")
+  (gruvbox-neutral_purple   "#8f3f71" "#875f87")
+  (gruvbox-neutral_aqua     "#427b58" "#5f8787")
+  (gruvbox-neutral_orange   "#af3a03" "#af5f00")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-light-medium-theme.el
+++ b/gruvbox-light-medium-theme.el
@@ -82,6 +82,14 @@
   (gruvbox-bright_aqua     "#427b58" "#5f8787")
   (gruvbox-bright_orange   "#af3a03" "#af5f00")
 
+  (gruvbox-neutral_red     "#9d0006" "#870000")
+  (gruvbox-neutral_green   "#79740e" "#878700")
+  (gruvbox-neutral_yellow  "#b57614" "#af8700")
+  (gruvbox-neutral_blue    "#076678" "#005f87")
+  (gruvbox-neutral_purple  "#8f3f71" "#875f87")
+  (gruvbox-neutral_aqua    "#427b58" "#5f8787")
+  (gruvbox-neutral_orange  "#af3a03" "#af5f00")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-light-soft-theme.el
+++ b/gruvbox-light-soft-theme.el
@@ -83,6 +83,14 @@
   (gruvbox-bright_aqua     "#427b58" "#5f8787")
   (gruvbox-bright_orange   "#af3a03" "#af5f00")
 
+  (gruvbox-neutral_red     "#9d0006" "#870000")
+  (gruvbox-neutral_green   "#79740e" "#878700")
+  (gruvbox-neutral_yellow  "#b57614" "#af8700")
+  (gruvbox-neutral_blue    "#076678" "#005f87")
+  (gruvbox-neutral_purple  "#8f3f71" "#875f87")
+  (gruvbox-neutral_aqua    "#427b58" "#5f8787")
+  (gruvbox-neutral_orange  "#af3a03" "#af5f00")
+
   (gruvbox-faded_red       "#cc241d" "#d75f5f")
   (gruvbox-faded_green     "#98971a" "#afaf00")
   (gruvbox-faded_yellow    "#d79921" "#ffaf00")

--- a/gruvbox-theme.el
+++ b/gruvbox-theme.el
@@ -88,6 +88,7 @@
   (gruvbox-neutral_blue    "#83a598" "#87afaf")
   (gruvbox-neutral_purple  "#d3869b" "#d787af")
   (gruvbox-neutral_aqua    "#8ec07c" "#87af87")
+  (gruvbox-neutral_orange  "#fe8019" "#ff8700")
 
   (gruvbox-faded_red       "#9d0006" "#870000")
   (gruvbox-faded_green     "#79740e" "#878700")


### PR DESCRIPTION
According to the documentation, the neutral and bright colors are almost identical.

- `gruvbox-neutral_orange` was missing in gruvbox-theme.el so I have created it as a copy of `gruvbox-bright_orange`.