### PR TITLE
Improve legibility of ido faces

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -441,9 +441,9 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (ivy-minibuffer-match-face-4               (:foreground gruvbox-faded_yellow))
 
      ;; ido
-     (ido-only-match                            (:foreground gruvbox-faded_green))
-     (ido-first-match                           (:foreground gruvbox-faded_green))
-     (ido-subdir                                (:foreground gruvbox-faded_red))
+     (ido-only-match                            (:foreground gruvbox-bright_green :weight 'bold))
+     (ido-first-match                           (:foreground gruvbox-light0_hard :weight 'bold :underline t))
+     (ido-subdir                                (:inherit 'dired-directory))
 
      ;; magit
      (magit-bisect-bad                          (:foreground gruvbox-faded_red))

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -441,7 +441,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (ivy-minibuffer-match-face-4               (:foreground gruvbox-faded_yellow))
 
      ;; ido
-     (ido-only-match                            (:foreground gruvbox-bright_green :weight 'bold))
+     (ido-only-match                            (:inherit 'success))
      (ido-first-match                           (:foreground gruvbox-light0_hard :weight 'bold :underline t))
      (ido-subdir                                (:inherit 'dired-directory))
 


### PR DESCRIPTION
# Old

I think in the current configuration the contrast for the matched items with the background is too low.  The fact that the minibuffer is usually also very small adds further to the poor legibility.

![](https://user-images.githubusercontent.com/1903556/81257447-67855f00-9087-11ea-9533-20d3c86a8e43.png)
![](https://user-images.githubusercontent.com/1903556/81257454-6b18e600-9087-11ea-9342-a3a778cd4710.png)
![](https://user-images.githubusercontent.com/1903556/81257457-6ce2a980-9087-11ea-81cd-6b2a4ab19065.png)

# New

This change proposed the following:

- Show `ido-only-match` in bold bright green, which is the same as `success`.
- Show `ido-first-match` in the default foreground color with bold and underline.  This matches `ivy-current-match`.
- Show `ido-subdir` in the same color as `dired-directory`.

I think these changes make the ido faces more legible and also more consistent with the rest of the theme.

![](https://user-images.githubusercontent.com/1903556/81258115-0c546c00-9089-11ea-8f43-c096f36c3688.png)
![](https://user-images.githubusercontent.com/1903556/81257579-b92de980-9087-11ea-951d-8275415364ef.png)