### PR TITLE
Add lsp mode coloring

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -567,6 +567,16 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (font-latex-warning-face                   (:foreground gruvbox-bright_red :weight 'bold))
      (preview-face                              (:background gruvbox-dark1))
 
+     ;; lsp
+     (lsp-lsp-flycheck-warning-unnecessary-face (:underline (:color gruvbox-bright_orange :style 'wave)
+                                                            :foreground gruvbox-burlywood4))
+     (lsp-ui-doc-background                     (:background gruvbox-dark3))
+     (lsp-ui-doc-header                         (:background gruvbox-faded_blue))
+     (lsp-ui-peek-filename                      (:foreground gruvbox-bright_red))
+     (lsp-ui-sideline-code-action               (:foreground gruvbox-bright_yellow))
+     (lsp-ui-sideline-current-symbol            (:foreground gruvbox-faded_aqua))
+     (lsp-ui-sideline-symbol                    (:foreground gruvbox-gray))
+
      ;; mu4e
      (mu4e-header-key-face                      (:foreground gruvbox-bright_green :weight 'bold ))
      (mu4e-unread-face                          (:foreground gruvbox-bright_blue :weight 'bold ))


### PR DESCRIPTION
Most of the faces inherit from other modes, these don't.

Sorry i kinda rushed these, there might be better colors, the original one is bright yellow, so totally unreadable.


![doc_box](https://user-images.githubusercontent.com/2660/93000463-f409c780-f528-11ea-89be-fdaa6f2c7b26.png)
![Screenshot from 2020-09-12 18-33-22](https://user-images.githubusercontent.com/2660/93000468-f8ce7b80-f528-11ea-8735-0c758ece1ddf.png)

