### PR TITLE
Better use of colors for Proof General

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This theme contains custom support for the following features and plugins:
 - [Neotree](https://github.com/jaypei/emacs-neotree)
 - Org
 - Popup
+- [Proof General](https://proofgeneral.github.io/)
 - [RainbowDelimiters](http://www.emacswiki.org/emacs/RainbowDelimiters)
 - Shell script
 - Smart modeline

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -837,11 +837,18 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (coq-solve-tactics-face      (:inherit 'font-lock-constant-face))
      (coq-cheat-face              (:box (:line-width -1 :color gruvbox-bright_red :style nil)
                                         :foreground gruvbox-bright_red))
+     (coq-button-face             (:background gruvbox-bg_inactive))
+     (coq-button-face-active      (:background gruvbox-dark1))
+     (coq-button-face-pressed     (:background gruvbox-bg_inactive))
 
      ;; Proof General
      (proof-active-area-face      (:underline t))
      (proof-tacticals-name-face   (:inherit 'font-lock-constant-face))
      (proof-tactics-name-face     (:inherit 'font-lock-constant-face))
+     (proof-locked-face           (:background gruvbox-dark1))
+     (proof-queue-face            (:background gruvbox-dark2))
+     (proof-warning-face          (:background gruvbox-dark_red))
+     (proof-error-face            (:background gruvbox-bg :foreground gruvbox-faded_red))
 
      ;; ledger-mode
      (ledger-font-xact-highlight-face  (:background gruvbox-dark1))


### PR DESCRIPTION
Proof General sets some default colours which are not very nice on a dark BG (see screenshots).
This PR ensures that the colors are more consistent with the general gruvbox style
![Screenshot_2021-12-30_21-00-49](https://user-images.githubusercontent.com/2814972/147788774-8099c336-1b0f-4a5a-9c94-9aa1a3a94699.png)
![Screenshot_2021-12-30_20-55-59](https://user-images.githubusercontent.com/2814972/147788776-25386840-f0d2-46c8-b8f1-56b8754a8403.png)
