### PR TITLE
Add NonGNU ELPA instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ enabled by default in Emacs 28 or later, so just type `M-x package-install`.
 
 If you're an Emacs 24 user or you have a recent version of `package.el` you can
 install the Gruvbox theme from the [MELPA
-repository](http://melpa.milkbox.net/#/gruvbox-theme).
+repository](https://melpa.org/#/gruvbox-theme).
 
 ### No `package.el`
 
-The following instructions are for in the case where you don't have access to
-`package.el` for some reason.
+Use the following instructions if you don't have access to `package.el` for some
+reason.
 
 1. Download `gruvbox-theme.el`, and put it in `~/.emacs.d/themes`. For example:
    ```shell

--- a/README.md
+++ b/README.md
@@ -111,14 +111,20 @@ This theme contains custom support for the following features and plugins:
 
 ## Installation and usage
 
-The recommended way to install the Gruvbox theme is with MELPA.
+The recommended way to install the Gruvbox theme is with NonGNU ELPA or MELPA.
+The version of `gruvbox-theme` there will always be up-to-date.
+
+### NonGNU ELPA
+
+You can install Gruvbox from [NonGNU
+ELPA](http://elpa.nongnu.org/nongnu/gruvbox-theme.html).  This archive is
+enabled by default in Emacs 28 or later, so just type `M-x package-install`.
 
 ### MELPA
 
 If you're an Emacs 24 user or you have a recent version of `package.el` you can
 install the Gruvbox theme from the [MELPA
-repository](http://melpa.milkbox.net/#/gruvbox-theme). The version of
-`gruvbox-theme` there will always be up-to-date.
+repository](http://melpa.milkbox.net/#/gruvbox-theme).
 
 ### No `package.el`
 


### PR DESCRIPTION
Hi!

We have now added this package to [NonGNU ELPA](http://elpa.nongnu.org/nongnu/gruvbox-theme.html) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others. This commit adds installation instructions to README.md.

The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will be automatically when you bump the "Version" commentary header in this repository. You can bump the package version (thereby releasing a new version) at your convenience.

Please let me know if you have any questions about any of this.

Thanks!