### PR TITLE
Use corfu-default instead of corfu-background

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -335,7 +335,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (marginalia-documentation                  (:italic t :foreground gruvbox-light3))
 
      ;; corfu
-     (corfu-background                          (:background gruvbox-dark1))
+     (corfu-default                             (:inherit 'tooltip))
      (corfu-current                             (:foreground gruvbox-bright_purple :background gruvbox-dark2))
      (corfu-bar                                 (:background gruvbox-dark2))
      (corfu-border                              (:background gruvbox-dark1))


### PR DESCRIPTION
The `corfu-background` doesn't exist. See [corfu source code.](https://github.com/minad/corfu/blob/main/corfu.el) The `corfu-default` should be used instead.
Also, the proper background is inherited from `'tooltip`.

[REMOVED] `(corfu-background (:background gruvbox-dark1))`
[ADDED] `(corfu-default (:inherit 'tooltip))`

Dark:
![image](https://i.ibb.co/0FSrvHw/difference.jpg)

Light (After):
![image](https://i.ibb.co/NpVzcqp/after-light.jpg)
