### PR TITLE
Add font-lock-number and font-lock-property faces

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -113,8 +113,10 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (font-lock-function-name-face                      (:foreground gruvbox-bright_yellow))
      (font-lock-keyword-face                            (:foreground gruvbox-bright_red))
      (font-lock-string-face                             (:foreground gruvbox-bright_green))
+     (font-lock-number-face                             (:foreground gruvbox-bright_purple))
      (font-lock-variable-name-face                      (:foreground gruvbox-bright_blue))
      (font-lock-type-face                               (:foreground gruvbox-bright_purple))
+     (font-lock-property-face                           (:foreground gruvbox-bright_purple))
      (font-lock-warning-face                            (:foreground gruvbox-bright_red :bold t))
 
      ;;; Basic faces

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -116,7 +116,7 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (font-lock-number-face                             (:foreground gruvbox-bright_purple))
      (font-lock-variable-name-face                      (:foreground gruvbox-bright_blue))
      (font-lock-type-face                               (:foreground gruvbox-bright_purple))
-     (font-lock-property-face                           (:foreground gruvbox-bright_purple))
+     (font-lock-property-face                           (:foreground gruvbox-bright_blue))
      (font-lock-warning-face                            (:foreground gruvbox-bright_red :bold t))
 
      ;;; Basic faces


### PR DESCRIPTION
These two faces are used with font-lock to fontify different aspects of the buffers. In particular, if using the new treesit feature in Emacs 29, numbers on tree-sitter enabled buffers will appear blank.

Also, considering members use bright_purple, let's stick to bright_purple on properties too. It was defaulting to the built-in one, making the fontified buffer blue, while the idea is to highlight also the variable names blue, which would be the way that they are currently highlighted when declared.

For both changes, I added screenshots using the new tsx-ts-mode and [kotlin-ts-mode](https://gitlab.com/bricka/emacs-kotlin-ts-mode). What would change for numbers would be the numbers appearing white first, and then bright_purple. On the property change would be the members being blue moving to bright_purple.

### font-lock-number-face

#### Before
<img width="833" alt="number1" src="https://user-images.githubusercontent.com/47970396/209991143-cb981984-1d8e-4acd-bd81-e62ab5c71bb2.png">
<img width="833" alt="number2" src="https://user-images.githubusercontent.com/47970396/209991150-44db28db-7540-403a-a28e-aef3674940b3.png">

#### After
<img width="833" alt="number3" src="https://user-images.githubusercontent.com/47970396/209991164-6223d59f-dcfe-4d0a-b35b-c2cb0bed0c48.png">
<img width="833" alt="number4" src="https://user-images.githubusercontent.com/47970396/209991338-75f5ffff-c604-4bd1-b064-07d7b43d0f30.png">

### font-lock-property-face

#### Before
<img width="833" alt="property1" src="https://user-images.githubusercontent.com/47970396/209991182-caaa033b-3233-4111-b6b2-554ce69a55b5.png">
<img width="833" alt="property2" src="https://user-images.githubusercontent.com/47970396/209991186-00a6bc28-e5a9-458a-8118-7641f4e94f02.png">

#### After
<img width="833" alt="property3" src="https://user-images.githubusercontent.com/47970396/209991195-90b64294-ee84-4286-8286-416689cba042.png">
<img width="833" alt="property4" src="https://user-images.githubusercontent.com/47970396/209991199-31ce5dfb-493b-4a3f-a1b3-2c987a407ffc.png">




