### PR TITLE
Fixes Issue #200 - Bad contrast

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -469,9 +469,9 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
 
      ;;; isearch
 
-     (isearch                                   (:foreground gruvbox-black :background gruvbox-bright_orange))
-     (lazy-highlight                            (:foreground gruvbox-black :background gruvbox-bright_yellow))
-     (isearch-fail                              (:foreground gruvbox-light0 :background gruvbox-bright_red))
+     (isearch                                   (:foreground gruvbox-bg :background gruvbox-bright_orange))
+     (lazy-highlight                            (:foreground gruvbox-bg :background gruvbox-bright_yellow))
+     (isearch-fail                              (:foreground gruvbox-bg :background gruvbox-bright_red))
 
      ;;; markdown-mode
 


### PR DESCRIPTION
# Fixes Contrast issue.

isearch set to Black which in light themes will lead to poor contrast.
![Screenshot_2023-03-15_10-11-18](https://user-images.githubusercontent.com/74180458/225278509-10df457a-41d8-46f3-aeac-e584658e446a.png)
