### PR TITLE
Support vc-*-state faces, #210

### DIFF
--- a/gruvbox.el
+++ b/gruvbox.el
@@ -628,6 +628,12 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
      (diff-hl-delete (:background gruvbox-faded_red :foreground gruvbox-faded_red))
      (diff-hl-insert (:background gruvbox-faded_green :foreground gruvbox-faded_green))
 
+     ;;; vc (builtin)
+
+     (vc-edited-state (:background gruvbox-faded_blue :foreground gruvbox-faded_blue))
+     (vc-removed-state (:background gruvbox-faded_red :foreground gruvbox-faded_red))
+     (vc-locally-added-state (:background gruvbox-faded_green :foreground gruvbox-faded_green))
+
      ;;; flyspell
 
      (flyspell-duplicate                        (:underline (:color gruvbox-light4 :style 'line)))


### PR DESCRIPTION
These faces are used by dirvish, aligning with diff-hl seems nice.

Given this magit status:

<img width="388" alt="image" src="https://github.com/greduan/emacs-theme-gruvbox/assets/10142314/02994b7c-caaf-4477-84cb-9a6f09911c6b">

Before change:

<img width="486" alt="image" src="https://github.com/greduan/emacs-theme-gruvbox/assets/10142314/10516198-a039-4581-8f19-ff4eb5fe6f14">

After change:

<img width="368" alt="image" src="https://github.com/greduan/emacs-theme-gruvbox/assets/10142314/f29bb20f-f341-44f8-b395-f0060d282e5b">

Faces added by this PR are applied on `b` `1.txt` `2.txt`.