### PR TITLE
Use less common colors for `orderless` match faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This theme contains custom support for the following features and plugins:
 - Markdown
 - Message
 - [Neotree](https://github.com/jaypei/emacs-neotree)
+- [Orderless](https://github.com/oantolin/orderless)
 - Org
 - Popup
 - [Proof General](https://proofgeneral.github.io/)

--- a/gruvbox.el
+++ b/gruvbox.el
@@ -527,10 +527,10 @@ Should contain 2 %s constructs to allow for theme name and directory/prefix")
 
      ;;; orderless
 
-     (orderless-match-face-0                    (:foreground gruvbox-bright_yellow))
-     (orderless-match-face-1                    (:foreground gruvbox-bright_orange))
-     (orderless-match-face-2                    (:foreground gruvbox-bright_blue))
-     (orderless-match-face-3                    (:foreground gruvbox-bright_purple))
+     (orderless-match-face-0                    (:weight 'bold :foreground gruvbox-lightblue4))
+     (orderless-match-face-1                    (:weight 'bold :foreground gruvbox-delimiter-four))
+     (orderless-match-face-2                    (:weight 'bold :foreground gruvbox-delimiter-three))
+     (orderless-match-face-3                    (:weight 'bold :foreground gruvbox-faded_yellow))
 
      ;;; magit
 


### PR DESCRIPTION
`gruvbox-bright_*` colors are heavily used, so the `orderless`-matched strings may not show in certain contexts, e.g., when using `consult-buffer`.

This commit adopts less used colors for `orderless` match faces. The color scheme is similar to `orderless`'s default `blue`, `magenta`, `green` and `yellow`.

Also update README to reflect support status for the `orderless` package.

I've played around with different colors and chosen the ones that are relatively distinguishable and easy one the eyes. However, I don't know if colors like `gruvbox-delimiter-three` are supposed to be used only with `RainbowDelimiters` mode.

Before:
<img width="863" alt="Screenshot 2025-01-15 at 10 06 33 PM" src="https://github.com/user-attachments/assets/938f5c9c-f4b4-4eca-96ac-48544a186164" />
<img width="877" alt="Screenshot 2025-01-15 at 10 23 50 PM" src="https://github.com/user-attachments/assets/8cceee4b-e6af-4442-9338-e1c23d47666a" />
After:
<img width="862" alt="Screenshot 2025-01-15 at 11 58 58 PM" src="https://github.com/user-attachments/assets/42ce18e8-90a5-4cc5-bc3e-f5a3831abb6d" />
<img width="866" alt="Screenshot 2025-01-16 at 12 00 03 AM" src="https://github.com/user-attachments/assets/91777807-0eb2-482e-a23f-05f04a7fc3be" />